### PR TITLE
Output export errors to txt file

### DIFF
--- a/AssetStudio.GUI/Studio.cs
+++ b/AssetStudio.GUI/Studio.cs
@@ -525,6 +525,8 @@ namespace AssetStudio.GUI
 
                 int toExportCount = toExportAssets.Count;
                 int exportedCount = 0;
+                string logFilePath = "";
+                bool ExportError = false;
                 int i = 0;
                 Progress.Reset();
                 foreach (var asset in toExportAssets)
@@ -593,9 +595,31 @@ namespace AssetStudio.GUI
                     }
                     catch (Exception ex)
                     {
-                        MessageBox.Show($"Export {asset.Type}:{asset.Text} error\r\n{ex.Message}\r\n{ex.StackTrace}");
+                        try
+                        {
+                            string directory = AppDomain.CurrentDomain.BaseDirectory;
+                            logFilePath = Path.Combine(directory, "log_error.txt");
+                            string prevLogFilePath = Path.Combine(directory, "log_error_prev.txt");
+                            if (!ExportError)
+                            {
+                                if (File.Exists(logFilePath))
+                                {
+                                    if (File.Exists(prevLogFilePath))
+                                    {
+                                        File.Delete(prevLogFilePath);
+                                    }
+                                    File.Move(logFilePath, prevLogFilePath);
+                                }
+                                File.AppendAllText(logFilePath, $"Export Errors:" + $"Version {Application.ProductVersion}" + Environment.NewLine + $"----------" + Environment.NewLine);
+                                ExportError = true;
+                            };
+                            File.AppendAllText(logFilePath, $"Export {asset.Type}:{asset.Text} error\r\n{ex.Message}\r\n{ex.StackTrace}" + Environment.NewLine + Environment.NewLine);
+                        }
+                        catch (Exception ex2)
+                        {
+                            Console.WriteLine("Error saving to log file: " + ex2.Message);
+                        }
                     }
-
                     Progress.Report(++i, toExportCount);
                 }
 
@@ -605,6 +629,11 @@ namespace AssetStudio.GUI
                 {
                     statusText += $" {toExportCount - exportedCount} assets skipped (not extractable or files already exist)";
                 }
+                if (ExportError)
+                {
+                    Process.Start("notepad.exe", logFilePath);
+                }
+
 
                 StatusStripUpdate(statusText);
 


### PR DESCRIPTION
"To avoid the process halting due to output errors, I have instead implemented output to a text file. After the output is complete, a text file containing error logs will be opened in Notepad."